### PR TITLE
Read for later view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12941,6 +12941,21 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
       "integrity": "sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw=="
     },
+    "react-icons": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.11.0.tgz",
+      "integrity": "sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==",
+      "requires": {
+        "camelcase": "^5.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        }
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-icons": "^3.11.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
     "web-vitals": "^0.2.4"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^12.2.0",
     "moment": "^2.29.1",
     "node-sass": "^4.14.1",
+    "npm installreact-dom": "^17.0.1",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -18,6 +18,7 @@ export class App extends Component {
     }
   }
 
+  
   saveReading = (event) => {
     const id = event.target.id.split('#')
     const allNewsCopy = this.state.newsData

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -18,19 +18,116 @@ export class App extends Component {
       currentCategory: {},
       laterReadings:[],
       error: '',
+      searchedItems: {
+        query:'',
+        category:'',
+        results:[],
+        searchHistory:[]
+      },
     }
   }
 
+  updateHomePage =  (news) => {
+    return news.reduce((data, story) =>{
+      data.section= story.section
+      data.topStories.push(story)
+      data.last_updated= story.updated_date
+      data.id= Date.now()
+      data.newsType= 'Your Search'
+    return data 
+    },{topStories: []})
+  }
 
+  findUserStory = () => {
+    const { category, query } = this.state.searchedItems
+    if (!query && !category) {
+      return this.setState({error: 'please choose a criteria'})
+      
+    }
+    if (!category){
+      return this.setState({error: 'you must select a category'})
+      
+    } 
+    if (!query) {
+      return this.setState({error: 'what do you want to look for?'})
+      
+    }
+    const stories = this.state.newsData[category].results.filter(story => {
+      return story.title.toLowerCase().includes(query)
+    })
+    if (stories.length === 0 ) {
+      return this.setState({error: 'no items found'})
+      
+    }
+    const newsFound = this.updateHomePage(stories)
+    
+    this.setState(state => ({
+      currentCategory: newsFound,
+      searchedItems: {...state.searchedItems,
+        results:  stories,
+        searchHistory: [...state.searchedItems.searchHistory, stories ]
+      }
+    }))
+  }
+
+  updateSearchCategory = (event) => {
+    this.setState(state => ({
+      searchedItems: {...state.searchedItems,
+          category: event.target.value
+      }
+    }))
+  }
+
+  updateSearchQuery = (event) => {
+    this.setState(prevState => ({
+      searchedItems: {...prevState.searchedItems,
+          query: event.target.value
+      }
+    }))
+  }
+
+  injectOptionsCategories = () =>{
+    return this.state.allNewsCategories.map((category,i) => {
+      return(<option 
+        key={i}
+        value={category}
+        id={category}
+        name={category}>
+        {category}</option>)
+    })
+  }
+
+  deleteAllSavedStories = () => {
+    this.setState({ laterReadings: []})
+  }
+  
+  deleteSavedReading = (event) =>{
+    const id = event.target.id.split('#')
+    const copyOfSavedStories = [...this.state.laterReadings]
+    const itemToDelete = copyOfSavedStories.find(story => {
+      return story.newsType === id[0]
+    })
+    itemToDelete.saved = !itemToDelete.saved
+    const index = copyOfSavedStories.indexOf(itemToDelete)
+    if(index !== -1){
+      copyOfSavedStories.splice(index, 1)
+      this.setState({ laterReadings: copyOfSavedStories})
+    }
+  } 
+  
   saveReading = (event) => {
     const id = event.target.id.split('#')
     const allNewsCopy = this.state.newsData
     const savedElement = allNewsCopy[id[0]].results.find(entry => {
       return entry.created_date === id[1]
     });
-    this.setState({laterReadings: [...this.state.laterReadings, savedElement]})
+    savedElement.newsType = id[0]
+    savedElement.saved = !savedElement.saved
+    if (!this.state.laterReadings.includes(savedElement)) {
+      this.setState({laterReadings: [...this.state.laterReadings, savedElement]})
+    }
   }
-
+  
   componentDidMount =  async () => {
     await this.requestData()
   }
@@ -46,19 +143,21 @@ export class App extends Component {
       data.section = chosenOne.section
       data.topStories = chosenOne.results
       data.last_updated = chosenOne.last_updated
-      data.id = chosenOne.created_date
-      data.dataType = category
+      data.id = Date.now()
+      data.newsType = category
+      data.topStories.forEach(story =>story.saved= false)
       return data
     }, {})
+    console.log(newData)
     this.setState(prevState => ({
-      currentCategory: {...prevState.currentCategory =   newData}
+      currentCategory: {...prevState.currentCategory = newData}
     }))
   }
 
   requestData = async() => {
     try{
       await allNewsCategories.forEach(category =>{
-        const promise = getTopStories(category)
+         getTopStories(category)
         .then(data =>  this.setState(prevState => ({
           newsData: {
              ...prevState.newsData,
@@ -67,7 +166,6 @@ export class App extends Component {
         })))
       })
     } catch(error){
-      console.log(error)
       this.setState({error})
     }
   }
@@ -90,41 +188,72 @@ export class App extends Component {
               <h5 className="app-title">{moment().format('LLL')}</h5>
             </div>
             <div className="title-container">
-              <h1 className="app-title">CommuniKaté</h1>
+              <h1 className="app-title">CommuniK</h1>
               <h3 className="sub-title">Top stories Only</h3>
             </div>
-            <div className="controls-container">
+            <div className="control-container">
           </div>
         </nav>
 
         <section className="banner">
           <div className="banner-container">
-            <div className="interactive-controls">
-            <Link
-              to='/home'>
-              <button 
-              className="app-title">
-              home
-              </button>
-            </Link>
-            <Link
-              to='/my_reads'>
-              <button 
-              className="app-title">
-              My reads
-              </button>
-            </Link>
-
-            <Link to='/home'>
-              <button 
-                onClick={this.generateRandomCategory}
-                className="app-title">
-                randomize
-                </button>
-            </Link>
+          <div className="search-container">
+                <div className="inner-search-container">
+                  <select 
+                    value={this.state.searchedItems.category}
+                    onChange={(event) => {this.updateSearchCategory(event)}}>
+                    <option 
+                      placeholder='category'
+                      value=''>categories</option>
+                      {this.injectOptionsCategories()}
+                  </select>
+                  <input 
+                    value= {this.state.searchedItems.query}
+                    onChange={this.updateSearchQuery}
+                    placeholder='search'
+                    name='searchedItem'
+                    type="text" 
+                    className="search-bar"/>
+                    <i className="fas fa-search"
+                      onClick={this.findUserStory}
+                    ></i>
+                </div>
+                {this.state.error && <p className="error-message">{this.state.error}</p>}
             </div>
+            <div className="interactive-controls">
+              <Link
+                to='/home'>
+                <button 
+                className="app-title">
+                home
+                </button>
+              </Link>
+
+              <Link
+                to='/my_reads'>
+                <button 
+                className="app-title">My reads</button>
+              </Link>
+
+              {this.state.laterReadings.length > 0 && <Link
+                to='/my_reads'>
+                <button 
+                onClick={this.deleteAllSavedStories}
+                className="app-title">Delete All</button>
+              </Link>}
+
+              <Link to='/home'>
+                <button 
+                  onClick={this.generateRandomCategory}
+                  className="app-title">randomize</button>
+              </Link>
+            </div>
+
+
+
           </div>
         </section>
+
         <Switch>
             <Route 
             exact
@@ -140,9 +269,18 @@ export class App extends Component {
             <Route 
               exact
               path='/my_reads'>
-                <LaterReads/>
+                <LaterReads
+                  laterReadings={this.state.laterReadings}
+                  deleteSavedReading={this.deleteSavedReading}
+                />
             </Route>
-
+            
+            <Route
+              path='/*'>
+              <div className="error-contianer">
+                <h1 className="error">Oops, something went wrong</h1>
+              </div>
+            </Route>
         </Switch>
       </div>
     )

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -3,7 +3,10 @@ import './App.scss';
 import { getTopStories } from '../../apiCalls'
 import allNewsCategories from '../../data/data'
 import { HomePage } from '../HomePage/HomePage'
-// import { Route, Router, Switch } from 'react-router-dom';
+import { LaterReads } from '../LaterReads/LaterReads'
+import { Switch, Route, Link} from "react-router-dom";
+
+import moment from 'moment'
 export class App extends Component {
   constructor(){
     super()
@@ -18,7 +21,7 @@ export class App extends Component {
     }
   }
 
-  
+
   saveReading = (event) => {
     const id = event.target.id.split('#')
     const allNewsCopy = this.state.newsData
@@ -81,17 +84,66 @@ export class App extends Component {
 
     return (
       <div className="App">
+      
+        <nav className="nav-bar">
+          <div className="day-information">
+              <h5 className="app-title">{moment().format('LLL')}</h5>
+            </div>
+            <div className="title-container">
+              <h1 className="app-title">CommuniKaté</h1>
+              <h3 className="sub-title">Top stories Only</h3>
+            </div>
+            <div className="controls-container">
+          </div>
+        </nav>
 
+        <section className="banner">
+          <div className="banner-container">
+            <div className="interactive-controls">
+            <Link
+              to='/home'>
+              <button 
+              className="app-title">
+              home
+              </button>
+            </Link>
+            <Link
+              to='/my_reads'>
+              <button 
+              className="app-title">
+              My reads
+              </button>
+            </Link>
 
-        <HomePage 
-          newsData={this.state.newsData}
-          selectCategory={this.selectCategory}
-          currentCategory={this.state.currentCategory}
-          generateRandomCategory={this.generateRandomCategory}
-          saveReading={this.saveReading}
-        />
+            <Link to='/home'>
+              <button 
+                onClick={this.generateRandomCategory}
+                className="app-title">
+                randomize
+                </button>
+            </Link>
+            </div>
+          </div>
+        </section>
+        <Switch>
+            <Route 
+            exact
+            path='/home'>
+              <HomePage 
+                newsData={this.state.newsData}
+                selectCategory={this.selectCategory}
+                currentCategory={this.state.currentCategory}
+                saveReading={this.saveReading}
+              />
+            </Route>
 
+            <Route 
+              exact
+              path='/my_reads'>
+                <LaterReads/>
+            </Route>
 
+        </Switch>
       </div>
     )
   }

--- a/src/Components/App/App.scss
+++ b/src/Components/App/App.scss
@@ -38,18 +38,57 @@
   .banner{
     height: 12vh;
     background-color: bisque;
-    overflow: scroll;
 
     .banner-container{
-        height: 100%;
+        /* height: 100%; */
         margin: 1% 0% 0% 0%;
-        padding: 1%;
+        /* padding: 1%; */
         background-color: blueviolet;
         display: inline-flex;
         width: 100%;
-
+        justify-content: space-around;
+        align-items: center;
         
+        .interactive-controls{
+            background-color: cyan;
+            width: 30%;
+            height: 30%;
+            color: darkgrey;
+        }
+
+        .search-container{
+            background-color: darkcyan;
+            margin: 0%;
+            width: 40%;
+            height: 10vh;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+
+            .inner-search-container{
+                padding:1%;
+                
+                .search-bar{
+                    width: 15vw;
+
+                }
+            }
+            .error-message{
+                margin: 0%;
+            }
+        }
     }
 }
+    .error-contianer{
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        height: 70vh;
+        background-color: darkkhaki;
+        background-image: url('https://images.unsplash.com/photo-1495020689067-958852a7765e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80');
+        .error{
+            font-size: 3em;
+        }
+    }
 }
 

--- a/src/Components/App/App.scss
+++ b/src/Components/App/App.scss
@@ -1,13 +1,55 @@
-
-
-html{
-  margin: 0% 20% 0% 20%;
-
-  width: 1200px;
-}
-
 .App {
-
+  margin: 0% 13% 0% 13%;
   text-align: center;
+
+  .nav-bar{
+    height: 20vh;
+    background-color: aqua;
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    grid-template-rows: repeat(4, 1fr);
+    
+    .day-information{
+        grid-area: 4/ 1/ 5/ 2;
+    }
+    
+    .title-container{
+        grid-area: 2/ 3/ 4/ 7;
+        justify-self: center;
+        align-items: center;
+
+        .app-title{
+            font-size: 4em;
+            margin: 2%;
+        }
+    }
+
+    .controls-container{
+        
+        display: flex;
+        justify-content: space-evenly;
+        flex-direction: column;
+        grid-area: 4/ 8/ 5/ 8;
+        padding: 2%;
+        margin: 2%;
+    }
+  }
+
+  .banner{
+    height: 12vh;
+    background-color: bisque;
+    overflow: scroll;
+
+    .banner-container{
+        height: 100%;
+        margin: 1% 0% 0% 0%;
+        padding: 1%;
+        background-color: blueviolet;
+        display: inline-flex;
+        width: 100%;
+
+        
+    }
+}
 }
 

--- a/src/Components/HomePage/HomePage.js
+++ b/src/Components/HomePage/HomePage.js
@@ -4,7 +4,6 @@ import moment from 'moment'
 import { FaClock } from "react-icons/fa";
 
 export const HomePage = (props) => {
-  // console.log(props)
     const tags = Object.keys(props.newsData).map((tag, i) => {
         return (
           <div 
@@ -36,19 +35,14 @@ export const HomePage = (props) => {
           <article 
             key={i}
             className="article-container">
-            
             <h2 className="article-title">{story.title}</h2>
-           
               <div
                 className="add-icon">
                   <i 
                   id={`${props.currentCategory.dataType}#${story.created_date}`}
                   onClick={(event) => props.saveReading(event)}
                   className="far fa-bookmark"></i>
-                </div>
-    
-       
-
+              </div>
             <img id={story.created_date} className="article-img" src={story.multimedia[0].url} alt={story.multimedia[0].caption}/>
             <div className="additional-info">
               <p className="info published_date">Published date {moment(story.published_date).format('LLLL')}</p>
@@ -68,35 +62,6 @@ export const HomePage = (props) => {
 
     return (
         <section className="homepage">
-          <nav className="nav-bar">
-            
-            <div className="day-information">
-                <h5 className="app-title">{moment().format('LLL')}</h5>
-            </div>
-
-            <div className="title-container">
-                <h1 className="app-title">CommuniKaté</h1>
-                <h3 className="sub-title">Top stories Only</h3>
-            </div>
-
-            <div className="controls-container">
-            </div>
-
-          </nav>
-
-          <section className="banner">
-            <div className="banner-container">
-                <div className="interactive-controls">
-                <button
-                  
-                  className="app-title">vie for later</button>
-                <button 
-                  onClick={props.generateRandomCategory}
-                  className="app-title">randomize</button>
-                </div>
-            </div>
-          </section>
-
           <section className="categories-container">
             <div className="categories">
             {tags}
@@ -106,97 +71,7 @@ export const HomePage = (props) => {
             <h1 className="news-section">{props.currentCategory.section}</h1>
                {handleCurrentCategory()}
             </div>
-
           </section>
         </section>
     )
 }
-
-
-/*
-{
-    "status": "OK",
-    "copyright": "Copyright (c) 2020 The New York Times Company. All Rights Reserved.",
-    "section": "U.S. News",
-    "last_updated": "2020-11-05T20:38:15-05:00",
-    "num_results": 25,
-    "results": [
-        {
-            "section": "us",
-            "subsection": "",
-            "title": "In a Year of Protest Cries, Now It’s ‘Count Every Vote!’ and ‘Stop the Steal!’",
-            "abstract": "Demonstrations have broken out all year long across America, and they have not let up as states tally ballots after Election Day.",
-            "url": "https://www.nytimes.com/2020/11/05/us/election-protests-vote-count.html",
-            "uri": "nyt://article/2380a63e-d24c-59c8-9413-a17171e45dc7",
-            "byline": "By Simon Romero, Shaila Dewan and Giulia McDonnell Nieto del Rio",
-            "item_type": "Article",
-            "updated_date": "2020-11-06T10:40:24-05:00",
-            "created_date": "2020-11-05T18:56:05-05:00",
-            "published_date": "2020-11-05T18:56:05-05:00",
-            "material_type_facet": "",
-            "kicker": "",
-            "des_facet": [
-                "Presidential Election of 2020",
-                "Demonstrations, Protests and Riots"
-            ],
-            "org_facet": [],
-            "per_facet": [
-                "Biden, Joseph R Jr",
-                "Trump, Donald J"
-            ],
-            "geo_facet": [],
-            "multimedia": [
-                {
-                    "url": "https://static01.nyt.com/images/2020/11/06/us/05votingprotests-1/merlin_179627493_327ec860-a692-42d8-a947-40ebbbe6223f-superJumbo.jpg",
-                    "format": "superJumbo",
-                    "height": 1365,
-                    "width": 2048,
-                    "type": "image",
-                    "subtype": "photo",
-                    "caption": "A &ldquo;Stop the Steal&rdquo; rally at the Pennsylvania State Capitol was one of the nationwide demonstrations on Thursday contesting the process of determining the next president.",
-                    "copyright": "Gabriela Bhaskar for The New York Times"
-                },
-                {
-                    "url": "https://static01.nyt.com/images/2020/11/06/us/05votingprotests-1/merlin_179627493_327ec860-a692-42d8-a947-40ebbbe6223f-thumbStandard.jpg",
-                    "format": "Standard Thumbnail",
-                    "height": 75,
-                    "width": 75,
-                    "type": "image",
-                    "subtype": "photo",
-                    "caption": "A &ldquo;Stop the Steal&rdquo; rally at the Pennsylvania State Capitol was one of the nationwide demonstrations on Thursday contesting the process of determining the next president.",
-                    "copyright": "Gabriela Bhaskar for The New York Times"
-                },
-                {
-                    "url": "https://static01.nyt.com/images/2020/11/06/us/05votingprotests-1/merlin_179627493_327ec860-a692-42d8-a947-40ebbbe6223f-thumbLarge.jpg",
-                    "format": "thumbLarge",
-                    "height": 150,
-                    "width": 150,
-                    "type": "image",
-                    "subtype": "photo",
-                    "caption": "A &ldquo;Stop the Steal&rdquo; rally at the Pennsylvania State Capitol was one of the nationwide demonstrations on Thursday contesting the process of determining the next president.",
-                    "copyright": "Gabriela Bhaskar for The New York Times"
-                },
-                {
-                    "url": "https://static01.nyt.com/images/2020/11/06/us/05votingprotests-1/merlin_179627493_327ec860-a692-42d8-a947-40ebbbe6223f-mediumThreeByTwo210.jpg",
-                    "format": "mediumThreeByTwo210",
-                    "height": 140,
-                    "width": 210,
-                    "type": "image",
-                    "subtype": "photo",
-                    "caption": "A &ldquo;Stop the Steal&rdquo; rally at the Pennsylvania State Capitol was one of the nationwide demonstrations on Thursday contesting the process of determining the next president.",
-                    "copyright": "Gabriela Bhaskar for The New York Times"
-                },
-                {
-                    "url": "https://static01.nyt.com/images/2020/11/06/us/05votingprotests-1/merlin_179627493_327ec860-a692-42d8-a947-40ebbbe6223f-articleInline.jpg",
-                    "format": "Normal",
-                    "height": 127,
-                    "width": 190,
-                    "type": "image",
-                    "subtype": "photo",
-                    "caption": "A &ldquo;Stop the Steal&rdquo; rally at the Pennsylvania State Capitol was one of the nationwide demonstrations on Thursday contesting the process of determining the next president.",
-                    "copyright": "Gabriela Bhaskar for The New York Times"
-                }
-            ],
-            "short_url": "https://nyti.ms/34ZwjaY"
-        },
-*/

--- a/src/Components/HomePage/HomePage.js
+++ b/src/Components/HomePage/HomePage.js
@@ -26,7 +26,8 @@ export const HomePage = (props) => {
         return (
           
           <article className="article-container">
-            <img className="cover-imge" src="https://images.unsplash.com/photo-1508612761958-e931d843bdd5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=658&q=80" alt=""/>
+            {/* <img className="cover-imge" src="https://images.unsplash.com/photo-1508612761958-e931d843bdd5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=658&q=80" alt=""/> */}
+            <h1 className="welcome">Welcome to Communik</h1>
           </article>
         )
       }
@@ -36,20 +37,25 @@ export const HomePage = (props) => {
             key={i}
             className="article-container">
             <h2 className="article-title">{story.title}</h2>
-              <div
-                className="add-icon">
-                  <i 
-                  id={`${props.currentCategory.dataType}#${story.created_date}`}
-                  onClick={(event) => props.saveReading(event)}
-                  className="far fa-bookmark"></i>
-              </div>
-            <img id={story.created_date} className="article-img" src={story.multimedia[0].url} alt={story.multimedia[0].caption}/>
-            <div className="additional-info">
-              <p className="info published_date">Published date {moment(story.published_date).format('LLLL')}</p>
-              <p className="info updated_date">Updated date {moment(story.updated_date).format('LLLL')}</p>
+
+            <div
+              className="add-icon">
+              {/* <h5 className="more">more</h5> */}
+              <a className="more" href={story.url} >more</a>
+                <i 
+                id={`${props.currentCategory.newsType}#${story.created_date}`}
+                onClick={(event) => props.saveReading(event)}
+                className={!story.saved ? "far fa-bookmark" :"fas fa-bookmark" }></i>
             </div>
-            <div className="abstract-container">
-              <p className="abstract-content">{story.abstract}</p>
+
+            <div className="image-container">
+              <img id={story.created_date} className="article-img" src={ story.multimedia ? story.multimedia[0].url :'https://upload.wikimedia.org/wikipedia/en/d/d6/Image_coming_soon.png'} alt={"image no available"}/>
+                {/* <img id='' className="article-img" src={story.multimedia[0].url} alt=''/> */}
+            </div>
+
+            <div className="additional-info">
+              {/* <p className="info published_date">Published date {moment(story.published_date).format('LLLL')}</p> */}
+              <p className="info updated_date">Updated date {moment(story.updated_date).format('LLLL')}</p>
             </div>
             <div className="by-line-container">
               <p className="by-line-content">{story.byline}</p>

--- a/src/Components/HomePage/HomePage.js
+++ b/src/Components/HomePage/HomePage.js
@@ -26,7 +26,6 @@ export const HomePage = (props) => {
         return (
           
           <article className="article-container">
-            {/* <img className="cover-imge" src="https://images.unsplash.com/photo-1508612761958-e931d843bdd5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=658&q=80" alt=""/> */}
             <h1 className="welcome">Welcome to Communik</h1>
           </article>
         )
@@ -39,8 +38,7 @@ export const HomePage = (props) => {
             <h2 className="article-title">{story.title}</h2>
 
             <div
-              className="add-icon">
-              {/* <h5 className="more">more</h5> */}
+              className="nyt-link-container">
               <a className="more" href={story.url} >more</a>
                 <i 
                 id={`${props.currentCategory.newsType}#${story.created_date}`}
@@ -49,8 +47,11 @@ export const HomePage = (props) => {
             </div>
 
             <div className="image-container">
-              <img id={story.created_date} className="article-img" src={ story.multimedia ? story.multimedia[0].url :'https://upload.wikimedia.org/wikipedia/en/d/d6/Image_coming_soon.png'} alt={"image no available"}/>
-                {/* <img id='' className="article-img" src={story.multimedia[0].url} alt=''/> */}
+              <img 
+                id={story.created_date} 
+                className="article-img" 
+                src={ story.multimedia ? story.multimedia[0].url :'https://upload.wikimedia.org/wikipedia/en/d/d6/Image_coming_soon.png'} 
+                alt={story.multimedia ? story.multimedia[0].caption : "image not available"}/>
             </div>
 
             <div className="additional-info">

--- a/src/Components/HomePage/HomePage.scss
+++ b/src/Components/HomePage/HomePage.scss
@@ -3,45 +3,57 @@
     height: 300vh;
 
     .categories-container{
-        background-color: chocolate;
+        background-color: rgb(249, 247, 245);
         height: 50%;
         display: grid;
         grid-template-columns: repeat(10, 1fr);
         grid-template-rows: repeat(10, 1fr);
         
+        .welcome{
+            grid-area: 1/ 1/ 3/ 6;
+             font-size: 3em;
+        }
+
         .categories{
             height: 100%;
-            background-color: darkcyan;
             grid-area: 1/ 1 / 10 / 4;
-            margin: 2%;
+            margin: 1%;
             display: grid;
             grid-template-columns: repeat(2, 1fr);
-            grid-template-rows: repeat(5, 1fr);
+            grid-template-rows: repeat(13, .5fr);
             grid-gap: 5px;
             align-content: center;
             grid-auto-flow: row;
             justify-content: center;
+            background-color: floralwhite;
+            grid-auto-flow: dense;
             
             .category{
-                background-color: darkred;
-                height: 7em;
+                height: 4em;
                 width: 7em;
-                border-radius: 50%;
                 justify-self: center;
                 align-self: center;
                 display: inline-flex;
                 justify-content: center;
                 align-items: center;
-                margin: 3%;
+                padding: 5%;
+
                 .category-name{
                     // align-self: center;
-                    color: darksalmon;
+                    padding: 2%;
+                    border-bottom: 3px solid transparent;
+                }
+                
+                .category-name:hover{
+                    border-bottom: 3px solid black;
+
                 }
             }
 
             .category:hover{
-                color: deepskyblue;
-                background-color: floralwhite;
+               
+               
+                border-bottom: 6px solid balck;
             }
         }
 
@@ -80,22 +92,26 @@
        
 
             .add-icon{
-                color: blue;
+                color: rgb(79, 98, 174);
                 font-size: 2em;
-                grid-area: 1/ 5 / 1 / 6;
-                z-index: 1;
-                margin: 1%;
-                border-radius: 2em;
-                justify-self: flex-end;
+                grid-area: 2/ 5 / 4 / 6;
                 text-decoration:none;
                 font-family:Arial;
-                display:block;
+                display:flex;
+                flex-direction: row;
                 width: 2em;
+                
+
+                .more{
+                    text-decoration: none;
+                    color: rgb(79, 98, 174);
+                    margin: 0% 35% 0% 5%;
+                }
                 
             }
 
             .add-icon:hover{
-                color: blue;
+                color: rgb(79, 98, 174);
                 
             }
         
@@ -112,22 +128,32 @@
                 
                 .article-title{
                     font-size: 1.3em;
-                    grid-area: 1/ 1 / 3 / 5;
+                   
+                    grid-area: 3/ 1 / 4 / 4;
                     height: 100%;
                     margin: 0%;
                 }
 
-                .article-img{
-
-                    grid-area: 1/ 5 / 7 / 5;
-                    height: 100%;
-                    margin: 0%;
+                .image-container{
+                    grid-area: 3/ 4 / 7 / 7;
+                    height: 20vh;
+                    padding: 0%;
+                    align-self: center;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+    
+                    .article-img{
+                        justify-content: center;
+                        height: 89%;
+                        background-color: honeydew;
+                    }
                 }
 
                 .additional-info{
                     margin: 1%;
 
-                    grid-area: 3/ 1 / 3 / 5;
+                    grid-area: 5/ 1 / 5 / 4;
                     display: inline-flex;
                     justify-content: space-around;
                     align-items: center;
@@ -150,7 +176,7 @@
                     margin: 1%;
                     font-size: .7em;
 
-                    grid-area: 6/ 1 / 8 / 5;
+                    grid-area: 6/ 3 / 7 / 4;
                 }
             }
         }

--- a/src/Components/HomePage/HomePage.scss
+++ b/src/Components/HomePage/HomePage.scss
@@ -1,10 +1,10 @@
 .homepage{
     background-color: aliceblue;
-    height: 300vh;
+    height: 200vh;
 
     .categories-container{
         background-color: rgb(249, 247, 245);
-        height: 50%;
+        height: 100%;
         display: grid;
         grid-template-columns: repeat(10, 1fr);
         grid-template-rows: repeat(10, 1fr);
@@ -91,7 +91,7 @@
 
        
 
-            .add-icon{
+            .nyt-link-container{
                 color: rgb(79, 98, 174);
                 font-size: 2em;
                 grid-area: 2/ 5 / 4 / 6;

--- a/src/Components/HomePage/HomePage.scss
+++ b/src/Components/HomePage/HomePage.scss
@@ -2,59 +2,9 @@
     background-color: aliceblue;
     height: 300vh;
 
-    .nav-bar{
-        height: 20vh;
-        background-color: aqua;
-        display: grid;
-        grid-template-columns: repeat(8, 1fr);
-        grid-template-rows: repeat(4, 1fr);
-        
-        .day-information{
-            grid-area: 4/ 1/ 5/ 2;
-        }
-        
-        .title-container{
-            grid-area: 2/ 3/ 4/ 7;
-            justify-self: center;
-            align-items: center;
-
-            .app-title{
-                font-size: 4em;
-                margin: 2%;
-            }
-        }
-
-        .controls-container{
-            
-            display: flex;
-            justify-content: space-evenly;
-            flex-direction: column;
-            grid-area: 4/ 8/ 5/ 8;
-            padding: 2%;
-            margin: 2%;
-        }
-    }
-
-    .banner{
-        height: 3%;
-        background-color: bisque;
-        overflow: scroll;
-
-        .banner-container{
-            height: 100%;
-            margin: 1% 0% 0% 0%;
-            padding: 1%;
-            background-color: blueviolet;
-            display: inline-flex;
-            width: 100%;
-
-            
-        }
-    }
-
     .categories-container{
         background-color: chocolate;
-        height: 40%;
+        height: 50%;
         display: grid;
         grid-template-columns: repeat(10, 1fr);
         grid-template-rows: repeat(10, 1fr);

--- a/src/Components/LaterReads/LaterReads.js
+++ b/src/Components/LaterReads/LaterReads.js
@@ -1,9 +1,62 @@
-import React from 'react'
+import React from 'react';
+import './LaterReads.scss';
+import moment from 'moment';
 
-export const LaterReads = () =>{
+export const LaterReads = (props) =>{
+    console.log(props)
+    const injectUserSaves = () => {
+        if(props.laterReadings.length === 0){
+            return <h1 className="sorry">Sorry but there are no readings</h1>
+        }
+        
+       return props.laterReadings.map(story => {
+           return(
+            <article className="story-container">
+                <div className="article-title-container">
+
+                <h2 className="article-title">{story.title}</h2>
+                </div>
+                
+                <div className="image-container">
+                  {/* <img id='' className="article-img" src={story.multimedia[0].url} alt=''/> */}
+                  <img id={story.created_date} className="article-img" src={ story.multimedia ? story.multimedia[0].url :'https://upload.wikimedia.org/wikipedia/en/d/d6/Image_coming_soon.png'} alt={"image no available"}/>
+                </div>
+
+                <div className="additional-info">
+                    <p className="info published_date">Published date {moment(story.published_date).format('LLLL')}</p>
+                    <p className="info updated_date">Updated date {moment(story.updated_date).format('LLLL')}</p>
+                </div>
+                <div className="abstract-container">
+                    <p className="abstract-content">{story.abstract}</p>
+                </div>
+                <div className="by-line-container">
+                    <p className="by-line-content">{story.byline}</p>
+                </div>
+                <div className="add-icon">
+                    <h6 className="listen-here">liste-here</h6>
+                    <a href={story.url} className="link"></a>
+                </div>
+
+                <div
+                    className="delete-icon">
+                    <i 
+                    id={`${story.newsType}#${story.created_date}`}
+                    onClick={(event) => props.deleteSavedReading(event)}
+                    className="fas fa-times-circle"></i>
+                   
+                </div>
+
+
+            </article>
+           )
+       })
+    }
     return (
         <div className="all-read-container">
-            <h1>hola</h1>
+            <div className="inner-container">
+                <h1 className="user-title">Your reads</h1>
+                {injectUserSaves()}
+            </div>
         </div>
     )
 }

--- a/src/Components/LaterReads/LaterReads.js
+++ b/src/Components/LaterReads/LaterReads.js
@@ -19,7 +19,11 @@ export const LaterReads = (props) =>{
                 
                 <div className="image-container">
                   {/* <img id='' className="article-img" src={story.multimedia[0].url} alt=''/> */}
-                  <img id={story.created_date} className="article-img" src={ story.multimedia ? story.multimedia[0].url :'https://upload.wikimedia.org/wikipedia/en/d/d6/Image_coming_soon.png'} alt={"image no available"}/>
+                  <img 
+                    id={story.created_date} 
+                    className="article-img" 
+                    src={ story.multimedia ? story.multimedia[0].url :'https://upload.wikimedia.org/wikipedia/en/d/d6/Image_coming_soon.png'} 
+                    alt={story.multimedia ? story.multimedia[0].caption : "image not available"}/>
                 </div>
 
                 <div className="additional-info">
@@ -32,9 +36,8 @@ export const LaterReads = (props) =>{
                 <div className="by-line-container">
                     <p className="by-line-content">{story.byline}</p>
                 </div>
-                <div className="add-icon">
-                    <h6 className="listen-here">liste-here</h6>
-                    <a href={story.url} className="link"></a>
+                <div className="nyt-link-container">
+                    <a className="more" href={story.url} >find more</a>
                 </div>
 
                 <div

--- a/src/Components/LaterReads/LaterReads.js
+++ b/src/Components/LaterReads/LaterReads.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export const LaterReads = () =>{
+    return (
+        <div className="all-read-container">
+            <h1>hola</h1>
+        </div>
+    )
+}

--- a/src/Components/LaterReads/LaterReads.scss
+++ b/src/Components/LaterReads/LaterReads.scss
@@ -19,19 +19,24 @@
             background-color: cornsilk;
             grid-area: 1/ span 12;
 
-       
-
-            .add-icon{
-                color: blue;
-                font-size: 2em;
+            .nyt-link-container{
+                color: rgb(79, 98, 174);
+                font-size: 1em;
                 grid-area: 6/ 7 / 7 / 9;
-                margin: 1%;
-                width: 100%;
+                text-decoration:none;
+                font-family:Arial;
+                margin: 4%;
 
-                .listen-here{
-                    font-size: .5em;
-                    margin: 5%;
+                .more{
+                    text-decoration: none;
+                    color: rgb(79, 98, 174);
+                    margin: 1%;
                 }
+
+                .more:hover{
+                    border-bottom: 2px solid black;
+                }
+                
             }
 
             .add-icon:hover{
@@ -49,6 +54,7 @@
                 grid-area: 1/ 5 / 3 / 9;
                 height: 100%;
                 margin: 2%;
+
                 .article-title{
                     font-size: 1em;
                 }
@@ -96,7 +102,6 @@
             .by-line-container{
                 margin: 1%;
                 font-size: .7em;
-
                 grid-area: 6/ 5 / 7 / 7;
             }
 

--- a/src/Components/LaterReads/LaterReads.scss
+++ b/src/Components/LaterReads/LaterReads.scss
@@ -1,0 +1,111 @@
+.all-read-container{
+    padding: 3%;
+    height: 100vh;
+    background-color: cadetblue;
+
+    .inner-container{
+        width: 90%;
+        padding: 5%;
+        height: 100vh;
+       display: flex;
+       flex-direction: column;
+
+        .story-container{
+            margin: 1%;
+            height: 30vh;
+            display: grid;
+            grid-template-columns: repeat(8, 1fr);
+            grid-template-rows: repeat(6, 1fr);
+            background-color: cornsilk;
+            grid-area: 1/ span 12;
+
+       
+
+            .add-icon{
+                color: blue;
+                font-size: 2em;
+                grid-area: 6/ 7 / 7 / 9;
+                margin: 1%;
+                width: 100%;
+
+                .listen-here{
+                    font-size: .5em;
+                    margin: 5%;
+                }
+            }
+
+            .add-icon:hover{
+                color: grey;
+                border: none;
+                
+                .clock{
+                    background-color: white;
+                }
+            }
+            
+            .article-title-container{
+
+                font-size: 1.3em;
+                grid-area: 1/ 5 / 3 / 9;
+                height: 100%;
+                margin: 2%;
+                .article-title{
+                    font-size: 1em;
+                }
+            }
+
+            .image-container{
+                grid-area: 1/ 1 / 7 / 5;
+                height: 30vh;
+                padding: 0%;
+                align-self: center;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+
+                .article-img{
+                    justify-content: center;
+                    height: 89%;
+                    background-color: honeydew;
+                }
+            }
+
+            .additional-info{
+                margin: 1%;
+
+                grid-area: 3/ 5 / 3 / 9;
+                display: inline-flex;
+                justify-content: space-around;
+                align-items: center;
+                
+
+                .info{
+                    color:grey;
+                    font-size: .8em;
+                    margin: 0%;
+                    align-content: flex-end;
+                }
+            }
+            
+            .abstract-container{
+                
+                grid-area: 4/ 5 / 6 / 9;
+                margin: 0%;
+            }
+
+            .by-line-container{
+                margin: 1%;
+                font-size: .7em;
+
+                grid-area: 6/ 5 / 7 / 7;
+            }
+
+            .delete-icon{
+                grid-area: 1/ 8 / 2 / 9;
+                margin: 16%;
+                justify-self: right;
+            }
+            
+        }
+    }
+}

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -1,8 +1,8 @@
 const allNewsCategories = [
     'arts', 
     'automobiles', 
-    // 'books',
-    // 'business',
+    'books',
+    'business',
     // 'fashion',
     // 'food', 
     // 'health', 

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './Components/App/App';
 import reportWebVitals from './reportWebVitals';
+import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.render(
+  <BrowserRouter>
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
+  </BrowserRouter>,
   document.getElementById('root')
 );
 


### PR DESCRIPTION
#### What's this PR do?  
- it Installs react-icon dependency 
- it defines `Routes` to `homepage` and `later reads`
- It adds the functionality to save stories to read for later



#### Where should the reviewer start? 
- `HomePage.js`
- `LaterReads.js`

#### How should this be manually tested?  

- run `npm start`
- On the homepage, 
   - select a news category
   - save some stories
   - `click` on the `my-reads` button

#### Any background context you want to provide?  
After installing `react-icons`  I decided to not use it because it was difficult for me to add the functionality using the icons. The `event` was not being read properly and decided to use the `<i>` tags from `font-awesome`.


#### What are the relevant tickets?
-This image shows how the card reacts after the user saves a story to read for later. The icon on the top right corner is not blue initially but it changes color accordingly.
-There is a but that is not allowing the user to un-colored the icon once has been removed from the section.

![Screen Shot 2020-11-08 at 7 35 52 AM](https://user-images.githubusercontent.com/56229864/98467881-0c970680-2195-11eb-9769-bfba23ca3f31.png)
#### Screenshots (if appropriate) 
- closes #11 
- closes #12
#### Questions:
