### PR TITLE
Save reads to local storage

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -27,6 +27,22 @@ export class App extends Component {
     }
   }
 
+  componentDidMount =  async () => {
+    await this.requestData()
+    this.retriveFromLocalStorage()
+  }
+  
+  retriveFromLocalStorage = () => {
+    const data = localStorage.getItem('laterReadings')
+    
+    this.setState({laterReadings: JSON.parse(data)})
+  }
+
+  saveToLocalStorage = () => {
+    const copyOfLaterReadings = [...this.state.laterReadings]
+    const save = localStorage.setItem('laterReadings',JSON.stringify(copyOfLaterReadings))
+  }
+
   updateHomePage =  (news) => {
     return news.reduce((data, story) =>{
       data.section= story.section
@@ -113,6 +129,7 @@ export class App extends Component {
       copyOfSavedStories.splice(index, 1)
       this.setState({ laterReadings: copyOfSavedStories})
     }
+    this.saveToLocalStorage()
   } 
   
   saveReading = (event) => {
@@ -126,10 +143,6 @@ export class App extends Component {
     if (!this.state.laterReadings.includes(savedElement)) {
       this.setState({laterReadings: [...this.state.laterReadings, savedElement]})
     }
-  }
-  
-  componentDidMount =  async () => {
-    await this.requestData()
   }
   
   generateRandomCategory =  () => {
@@ -148,7 +161,6 @@ export class App extends Component {
       data.topStories.forEach(story =>story.saved= false)
       return data
     }, {})
-    console.log(newData)
     this.setState(prevState => ({
       currentCategory: {...prevState.currentCategory = newData}
     }))
@@ -232,6 +244,7 @@ export class App extends Component {
               <Link
                 to='/my_reads'>
                 <button 
+                onClick={this.saveToLocalStorage}
                 className="app-title">My reads</button>
               </Link>
 

--- a/src/Components/HomePage/HomePage.js
+++ b/src/Components/HomePage/HomePage.js
@@ -21,6 +21,8 @@ export const HomePage = (props) => {
         )
     })
 
+
+
     const handleCurrentCategory = () => {
       if (!props.currentCategory.topStories) {
         return (

--- a/src/Components/LaterReads/LaterReads.js
+++ b/src/Components/LaterReads/LaterReads.js
@@ -3,7 +3,6 @@ import './LaterReads.scss';
 import moment from 'moment';
 
 export const LaterReads = (props) =>{
-    console.log(props)
     const injectUserSaves = () => {
         if(props.laterReadings.length === 0){
             return <h1 className="sorry">Sorry but there are no readings</h1>


### PR DESCRIPTION
#### What's this PR do?  
- it saves selected stories to local storage so the data can persist after the page reloads.
#### Where should the reviewer start? 
- `app.js`
#### How should this be manually tested?  
- On the homepage select some stories to read for later and reload the page, the data should persist. 
#### Any background context you want to provide?  

When the user selects a story to read for later, the information should persist after a reload.
#### What are the relevant tickets?  
closes #14
#### Screenshots (if appropriate) 
![Screen Shot 2020-11-08 at 8 25 06 AM](https://user-images.githubusercontent.com/56229864/98469313-f50f4c00-219b-11eb-8ad4-c512d5f41986.png)
